### PR TITLE
installs locale for locale-gen

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,10 @@
 
 export DEBIAN_FRONTEND=noninteractive
 
+echo "================ Installing locales ======================="
+apt-get clean && apt-get update
+apt-get install locales
+
 dpkg-divert --local --rename --add /sbin/initctl
 locale-gen en_US en_US.UTF-8
 dpkg-reconfigure locales


### PR DESCRIPTION
https://github.com/dry-dock/u16/issues/17

`locale-gen` started reporting `Command not found error` on  https://github.com/dry-dock/u16/blob/master/install.sh#L6

This is a fix for that.