### PR TITLE
Adds azure, digital ocean cli and ansible packages

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -90,6 +90,19 @@ sudo pip install 'awscli==1.11.44'
 echo "================= Adding awsebcli 3.9.0 ============"
 sudo pip install 'awsebcli==3.9.0'
 
+echo "================ Adding azure-cli 2.0 =============="
+echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ wheezy main" | \
+    sudo tee /etc/apt/sources.list.d/azure-cli.list
+sudo apt-key adv --keyserver packages.microsoft.com --recv-keys 417A0893
+sudo apt-get install apt-transport-https
+sudo apt-get update && sudo apt-get install azure-cli=0.2.8-1
+
+echo "================= Adding doctl 1.6.0 ============"
+curl -OL https://github.com/digitalocean/doctl/releases/download/v1.6.0/doctl-1.6.0-linux-amd64.tar.gz
+tar xf doctl-1.6.0-linux-amd64.tar.gz
+sudo mv ~/doctl /usr/local/bin
+rm doctl-1.6.0-linux-amd64.tar.gz
+
 echo "================= Adding jfrog-cli 1.7.0 ==================="
 wget -nv https://api.bintray.com/content/jfrog/jfrog-cli-go/1.7.0/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 -O jfrog
 sudo chmod +x jfrog
@@ -97,6 +110,18 @@ mv jfrog /usr/bin/jfrog
 
 echo "================ Adding ansible 2.3.0.0 ===================="
 sudo pip install 'ansible==2.3.0.0'
+
+echo "================ Adding boto 2.46.1 ======================="
+sudo pip install 'boto==2.46.1'
+
+echo "================ Adding apache-libcloud 2.0.0 ======================="
+sudo pip install 'apache-libcloud==2.0.0'
+
+echo "================ Adding azure 2.0.0 ======================="
+sudo pip install 'azure==2.0.0'
+
+echo "================ Adding dopy 0.3.7a ======================="
+sudo pip install 'dopy==0.3.7a'
 
 echo "================ Adding terraform-0.8.7===================="
 export TF_VERSION=0.8.7

--- a/install.sh
+++ b/install.sh
@@ -25,22 +25,22 @@ touch "$HOME/.ssh/known_hosts"
 
 echo "================= Installing basic packages ==================="
 apt-get install -y \
-    build-essential \
-    curl \
-    gcc \
-    gettext \
-    htop \
-    libxml2-dev \
-    libxslt-dev \
-    make \
-    nano \
-    openssh-client \
-    openssl \
-    software-properties-common \
-    sudo  \
-    texinfo \
-    unzip \
-    wget
+  build-essential \
+  curl \
+  gcc \
+  gettext \
+  htop \
+  libxml2-dev \
+  libxslt-dev \
+  make \
+  nano \
+  openssh-client \
+  openssl \
+  software-properties-common \
+  sudo  \
+  texinfo \
+  unzip \
+  wget
 
 echo "================= Installing Python packages ==================="
 apt-get install -y \
@@ -92,7 +92,7 @@ sudo pip install 'awsebcli==3.9.0'
 
 echo "================ Adding azure-cli 2.0 =============="
 echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ wheezy main" | \
-    sudo tee /etc/apt/sources.list.d/azure-cli.list
+  sudo tee /etc/apt/sources.list.d/azure-cli.list
 sudo apt-key adv --keyserver packages.microsoft.com --recv-keys 417A0893
 sudo apt-get install apt-transport-https
 sudo apt-get update && sudo apt-get install azure-cli=0.2.8-1


### PR DESCRIPTION
https://github.com/dry-dock/u16/issues/20

We have already installed ansible cli. Installing the following pakages, will help user to easily use the respective ansible modules. ( Ref: http://docs.ansible.com/ansible/list_of_cloud_modules.html )

AWS:
- https://pypi.python.org/pypi/boto

Google Cloud:
- https://libcloud.apache.org/

Azure:
- https://pypi.python.org/pypi/azure
- https://docs.microsoft.com/en-us/cli/azure/install-azure-cli

Dgitial Ocean:
- https://github.com/Wiredcraft/dopy
- https://www.digitalocean.com/community/tutorials/how-to-use-doctl-the-official-digitalocean-command-line-client