### PR TITLE
fix rvm install error for importing gpg keys

### DIFF
--- a/ruby/install.sh
+++ b/ruby/install.sh
@@ -3,7 +3,8 @@
 #adding keys
 
 cd /root
-sudo gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+# added to fix https://github.com/rvm/rvm/issues/3108
+curl -sSL https://rvm.io/mpapis.asc | sudo gpg --import -
 
 echo "================= Installing RVM ==================="
 curl -sSL https://get.rvm.io | bash -s stable


### PR DESCRIPTION
https://github.com/dry-dock/u16/issues/56

aims to fix current failing image builds - https://app.shippable.com/github/Shippable/jobs/build_u16/builds/598811e1e0b1120700a5aaa2/console 