### PR TITLE
upgrades apt-transport-https package version to 1.2.25

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -114,7 +114,7 @@ echo "================ Adding azure-cli $AZURE_CLI_VERSION =============="
 echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ wheezy main" | \
   sudo tee /etc/apt/sources.list.d/azure-cli.list
 sudo apt-key adv --keyserver packages.microsoft.com --recv-keys 417A0893
-sudo apt-get install -q apt-transport-https=1.2.24
+sudo apt-get install -q apt-transport-https=1.2.25
 sudo apt-get update && sudo apt-get install -q -y azure-cli=$AZURE_CLI_VERSION
 
 echo "================= Adding doctl 1.6.0 ============"


### PR DESCRIPTION
https://github.com/dry-dock/u16/issues/113

verified that the new image was getting built after updating the package version
![image](https://user-images.githubusercontent.com/11424742/36303747-31a6ff2a-1333-11e8-89d1-00ff60721f83.png)
