### PR TITLE
Fixed PATH expansion

### DIFF
--- a/java/install.sh
+++ b/java/install.sh
@@ -6,8 +6,8 @@ mkdir -p /usr/lib/jvm && cd /usr/lib/jvm
 wget --no-check-certificate -c --header "Cookie: oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/11+28/55eed80b163941c8885ad9298e6d786a/jdk-"$ORACLEJDK_VERSION"_linux-x64_bin.tar.gz
 tar -xzf jdk-"$ORACLEJDK_VERSION"_linux-x64_bin.tar.gz
 mv jdk-"$ORACLEJDK_VERSION"/ java-"$ORACLEJDK_VERSION"-oraclejdk-amd64
-echo "export JAVA_HOME=/usr/lib/jvm/java-"$ORACLEJDK_VERSION"-oraclejdk-amd64" >> /etc/drydock/.env
-echo "export PATH=$PATH:/usr/lib/jvm/java-"$ORACLEJDK_VERSION"-oraclejdk-amd64/bin" >> /etc/drydock/.env
+echo "export JAVA_HOME=/usr/lib/jvm/java-${ORACLEJDK_VERSION}-oraclejdk-amd64" >> /etc/drydock/.env
+echo "export PATH=\$PATH:/usr/lib/jvm/java-${ORACLEJDK_VERSION}-oraclejdk-amd64/bin" >> /etc/drydock/.env
 
 sudo update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-"$ORACLEJDK_VERSION"-oraclejdk-amd64/bin/java 1
 sudo update-alternatives --install /usr/bin/javac javac /usr/lib/jvm/java-"$ORACLEJDK_VERSION"-oraclejdk-amd64/bin/javac 1


### PR DESCRIPTION
Commit https://github.com/dry-dock/u16/commit/c007892c94e3d991b271eb39215510b5b2728e3a introduced an unexpected behavior of `$PATH`.

Normally `$PATH` can be expanded this way:

```console
$ docker run --rm -it ubuntu:16.04
$ root@aa190d3433ca:/# PATH="$PATH:/test" bash -c 'echo $PATH'
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/test
```

The change above introduced an unexpected behavior (notice missing `:/test` at the end):

```
$ docker run --rm -it drydock/u16
$ root@d248ceeef5de:/# PATH="$PATH:/test" bash -c 'echo $PATH'
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-11-oraclejdk-amd64/bin
```

The consequence is that basically if  anything adds something to `$PATH` the change is not propagated to any script calls, causing erroneous and very unexpected behavior. We noticed it when [bats](https://github.com/bats-core/bats-core) stopped working with the latest version of your images.